### PR TITLE
Fix multiple page parsing.

### DIFF
--- a/org.matthew.sonar.scraper/src/org/matthew/sonar/scraper/sonar/SonarQuery.java
+++ b/org.matthew.sonar.scraper/src/org/matthew/sonar/scraper/sonar/SonarQuery.java
@@ -19,7 +19,7 @@ package org.matthew.sonar.scraper.sonar;
 
 public class SonarQuery {
 	boolean maxResultsReached;
-	Paging info;
+	Paging paging;
 	Issue[] issues;
 	
 	public static class Paging{

--- a/org.matthew.sonar.scraper/src/org/matthew/sonar/scraper/sonar/test.java
+++ b/org.matthew.sonar.scraper/src/org/matthew/sonar/scraper/sonar/test.java
@@ -61,7 +61,7 @@ public class test {
 			}
 			issues.addAll(Arrays.asList(sq.issues));
 			page++;
-		} while (!sq.maxResultsReached && sq.issues.length != 0);
+		} while (sq.paging.getPages() > sq.paging.getPageIndex() && sq.issues.length != 0);
 		File file = new File("sonar.csv");
 		try (BufferedWriter bw = new BufferedWriter(new FileWriter(file))) {
 			bw.write(Issue.getHeader());


### PR DESCRIPTION
It turns out that MaxResultsReached is always true, so cannot be used to
know if there is more data available.  Instead, we can use paging.pages
and paging.pageIndex know if all data has been obtained.
